### PR TITLE
 Get multiple packets with their forms

### DIFF
--- a/src/UDS.Net.API.Client/IPacketClient.cs
+++ b/src/UDS.Net.API.Client/IPacketClient.cs
@@ -8,6 +8,8 @@ namespace UDS.Net.API.Client
     {
         Task<PacketDto> GetPacketWithForms(int id);
 
+        Task<List<PacketDto>> GetPacketsWithForms(int[] ids);
+
         Task<int> CountByStatusAndAssignee(string[] statuses, string assignedTo);
 
         Task<List<PacketDto>> GetPacketsByStatusAndAssignee(string[] statuses, string assignedTo, int pageSize = 10, int pageIndex = 1);

--- a/src/UDS.Net.API.Client/PacketClient.cs
+++ b/src/UDS.Net.API.Client/PacketClient.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.Linq;
 using System.Net.Http;
 using System.Text.Json;
 using System.Threading.Tasks;
@@ -22,6 +23,16 @@ namespace UDS.Net.API.Client
             PacketDto dto = JsonSerializer.Deserialize<PacketDto>(response, options);
 
             return dto;
+        }
+
+        public async Task<List<PacketDto>> GetPacketsWithForms(int[] ids)
+        {
+            var query = string.Join("&", ids.Select(id => $"ids={id}"));
+            var response = await GetRequest($"{_BasePath}/IncludeForms?{query}");
+
+            List<PacketDto> dtos = JsonSerializer.Deserialize<List<PacketDto>>(response, options);
+
+            return dtos;
         }
 
         public async Task<int> CountByStatusAndAssignee(string[] statuses, string assignedTo)

--- a/src/UDS.Net.API.Client/PacketClient.cs
+++ b/src/UDS.Net.API.Client/PacketClient.cs
@@ -27,12 +27,16 @@ namespace UDS.Net.API.Client
 
         public async Task<List<PacketDto>> GetPacketsWithForms(int[] ids)
         {
-            var query = string.Join("&", ids.Select(id => $"ids={id}"));
-            var response = await GetRequest($"{_BasePath}/IncludeForms?{query}");
+            if (ids != null && ids.Length > 0)
+            {
+                var query = string.Join("&", ids.Select(id => $"ids={id}"));
+                var response = await GetRequest($"{_BasePath}/IncludeForms?{query}");
 
-            List<PacketDto> dtos = JsonSerializer.Deserialize<List<PacketDto>>(response, options);
+                List<PacketDto> dtos = JsonSerializer.Deserialize<List<PacketDto>>(response, options);
 
-            return dtos;
+                return dtos;
+            }
+            return new List<PacketDto>();
         }
 
         public async Task<int> CountByStatusAndAssignee(string[] statuses, string assignedTo)

--- a/src/UDS.Net.API.Client/UDS.Net.API.Client.csproj
+++ b/src/UDS.Net.API.Client/UDS.Net.API.Client.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.API.Client</PackageId>
-		<Version>8.0.3</Version>
+		<Version>8.1.0</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>UDS client library for using UDS.Net.API</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Client library for API</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-api</RepositoryUrl>
-		<ReleaseVersion>8.0.3</ReleaseVersion>
+		<ReleaseVersion>8.1.0</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="System.Text.Json" Version="8.0.5" />

--- a/src/UDS.Net.API.Entities/UDS.Net.API.Entities.csproj
+++ b/src/UDS.Net.API.Entities/UDS.Net.API.Entities.csproj
@@ -5,13 +5,13 @@
 		<Nullable>enable</Nullable>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.API.Entities</PackageId>
-		<Version>8.0.3</Version>
+		<Version>8.1.0</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>UDS database entities</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Entities for API</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-api</RepositoryUrl>
-		<ReleaseVersion>8.0.3</ReleaseVersion>
+		<ReleaseVersion>8.1.0</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />

--- a/src/UDS.Net.API/Controllers/PacketsController.cs
+++ b/src/UDS.Net.API/Controllers/PacketsController.cs
@@ -218,6 +218,7 @@ namespace UDS.Net.API.Controllers
 
                 if (dto.PacketSubmissions != null && dto.PacketSubmissions.Count > 0)
                 {
+                    //TODO Use temporal data to pull the state of the packet at the time the submission record was created
                     foreach (var submission in dto.PacketSubmissions)
                     {
                         submission.Forms.AddRange(forms);

--- a/src/UDS.Net.API/Controllers/PacketsController.cs
+++ b/src/UDS.Net.API/Controllers/PacketsController.cs
@@ -150,6 +150,84 @@ namespace UDS.Net.API.Controllers
             return dto;
         }
 
+        [HttpGet("IncludeForms")]
+        public async Task<List<PacketDto>> GetPacketsWithForms(int[] ids)
+        {
+            var dtos = await _context.Visits
+                .Include(v => v.PacketSubmissions)
+                .ThenInclude(p => p.PacketSubmissionErrors)
+                .Where(v => ids.Contains(v.Id))
+                .AsNoTracking()
+                .Select(v => v.ToPacketDto())
+                .ToListAsync();
+
+            if (dtos.Count == 0)
+                return dtos;
+
+            var visits = await _context.Visits
+                .Include(v => v.A1)
+                .Include(v => v.A1a)
+                .Include(v => v.A2)
+                .Include(v => v.A3)
+                .Include(v => v.A4)
+                .Include(v => v.A4a)
+                .Include(v => v.A5D2)
+                .Include(v => v.B1)
+                .Include(v => v.B3)
+                .Include(v => v.B4)
+                .Include(v => v.B5)
+                .Include(v => v.B6)
+                .Include(v => v.B7)
+                .Include(v => v.B8)
+                .Include(v => v.B9)
+                .Include(v => v.C2)
+                .Include(v => v.D1a)
+                .Include(v => v.D1b)
+                .Where(v => ids.Contains(v.Id))
+                .AsNoTracking()
+                .ToListAsync();
+
+            foreach (var dto in dtos)
+            {
+                var visit = visits.FirstOrDefault(v => v.Id == dto.Id);
+                if (visit == null) continue;
+
+                var forms = new List<FormDto?>
+                {
+                   visit.A1?.ToFullDto(),
+                   visit.A1a?.ToFullDto(),
+                   visit.A2?.ToFullDto(),
+                   visit.A3?.ToFullDto(),
+                   visit.A4?.ToFullDto(),
+                   visit.A4a?.ToFullDto(),
+                   visit.A5D2?.ToFullDto(),
+                   visit.B1?.ToFullDto(),
+                   visit.B3?.ToFullDto(),
+                   visit.B4?.ToFullDto(),
+                   visit.B5?.ToFullDto(),
+                   visit.B6?.ToFullDto(),
+                   visit.B7?.ToFullDto(),
+                   visit.B8?.ToFullDto(),
+                   visit.B9?.ToFullDto(),
+                   visit.C2?.ToFullDto(),
+                   visit.D1a?.ToFullDto(),
+                   visit.D1b?.ToFullDto()
+                }.Where(f => f != null).ToList();
+
+                dto.Forms.AddRange(forms);
+
+                if (dto.PacketSubmissions != null && dto.PacketSubmissions.Count > 0)
+                {
+                    foreach (var submission in dto.PacketSubmissions)
+                    {
+                        submission.Forms.AddRange(forms);
+                    }
+                }
+            }
+
+            return dtos;
+        }
+
         /// <summary>
         /// Packets are not created, visits are the initial object
         /// </summary>

--- a/src/UDS.Net.API/UDS.Net.API.csproj
+++ b/src/UDS.Net.API/UDS.Net.API.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net8.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<ReleaseVersion>8.0.3</ReleaseVersion>
+		<ReleaseVersion>8.1.0</ReleaseVersion>
 		<DockerComposeProjectPath>../docker-compose.dcproj</DockerComposeProjectPath>
 		<UserSecretsId>c1dd1715-6fa0-4515-bcf2-6a7f6a0c11a5</UserSecretsId>
 		<Configurations>Release;Debug</Configurations>

--- a/src/UDS.Net.Dto/UDS.Net.Dto.csproj
+++ b/src/UDS.Net.Dto/UDS.Net.Dto.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.Dto</PackageId>
-		<Version>8.0.3</Version>
+		<Version>8.1.0</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>UDS data transfer objects for use with API</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Dtos for API</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-api</RepositoryUrl>
-		<ReleaseVersion>8.0.3</ReleaseVersion>
+		<ReleaseVersion>8.1.0</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="System.Text.Json" Version="8.0.5" />


### PR DESCRIPTION
Resolves #103 

This PR adds the ```GetPacketsWithForms``` which should allow users to get multiple packets along with their corresponding forms. Service methods have also been added to allow the front end app to implement this method.