### PR TITLE
RxNormId mapping fix

### DIFF
--- a/src/UDS.Net.API.Client/UDS.Net.API.Client.csproj
+++ b/src/UDS.Net.API.Client/UDS.Net.API.Client.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.API.Client</PackageId>
-		<Version>11.0.1</Version>
+		<Version>11.0.2</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>UDS client library for using UDS.Net.API</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Client library for API</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-api</RepositoryUrl>
-		<ReleaseVersion>11.0.1</ReleaseVersion>
+		<ReleaseVersion>11.0.2</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="System.Text.Json" Version="10.0.1" />

--- a/src/UDS.Net.API.Entities/UDS.Net.API.Entities.csproj
+++ b/src/UDS.Net.API.Entities/UDS.Net.API.Entities.csproj
@@ -5,13 +5,13 @@
 		<Nullable>enable</Nullable>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.API.Entities</PackageId>
-		<Version>11.0.1</Version>
+		<Version>11.0.2</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>UDS database entities</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Entities for API</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-api</RepositoryUrl>
-		<ReleaseVersion>11.0.1</ReleaseVersion>
+		<ReleaseVersion>11.0.2</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />

--- a/src/UDS.Net.API.Extensions/DtoToEntityMapper.cs
+++ b/src/UDS.Net.API.Extensions/DtoToEntityMapper.cs
@@ -623,9 +623,8 @@ namespace UDS.Net.API.Extensions
                 {
                     for (int i = 0; i < dto.A4DetailsDtos.Count && i < MAXINUMRECORDCOUNT; i++)
                     {
-                        var details = entity.GetType().GetProperty("RXNORMID" + (i + 1))?.GetValue(entity);
-
-                        details.GetType().GetProperty("RxNormId").SetValue(details, dto.A4DetailsDtos[i]);
+                        var rxProperty = entity.GetType().GetProperty("RXNORMID" + (i + 1));
+                        rxProperty?.SetValue(entity, dto.A4DetailsDtos[i]);
                     }
                 }
             }

--- a/src/UDS.Net.API.Extensions/UDS.Net.API.Extensions.csproj
+++ b/src/UDS.Net.API.Extensions/UDS.Net.API.Extensions.csproj
@@ -5,13 +5,13 @@
 		<Nullable>enable</Nullable>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.API.Extensions</PackageId>
-		<Version>11.0.1</Version>
+		<Version>11.0.2</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>UDS extensions for mapping between entities and dtos</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Mappers for entities and dtos</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-api</RepositoryUrl>
-		<ReleaseVersion>11.0.1</ReleaseVersion>
+		<ReleaseVersion>11.0.2</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\UDS.Net.Dto\UDS.Net.Dto.csproj" />

--- a/src/UDS.Net.API/UDS.Net.API.csproj
+++ b/src/UDS.Net.API/UDS.Net.API.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net10.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<ReleaseVersion>11.0.1</ReleaseVersion>
+		<ReleaseVersion>11.0.2</ReleaseVersion>
 		<DockerComposeProjectPath>../docker-compose.dcproj</DockerComposeProjectPath>
 		<UserSecretsId>c1dd1715-6fa0-4515-bcf2-6a7f6a0c11a5</UserSecretsId>
 		<Configurations>Release;Debug</Configurations>

--- a/src/UDS.Net.Dto/UDS.Net.Dto.csproj
+++ b/src/UDS.Net.Dto/UDS.Net.Dto.csproj
@@ -4,13 +4,13 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<OutputType>Library</OutputType>
 		<PackageId>UDS.Net.Dto</PackageId>
-		<Version>11.0.1</Version>
+		<Version>11.0.2</Version>
 		<Authors>Sanders-Brown Center on Aging</Authors>
 		<Description>UDS data transfer objects for use with API</Description>
 		<Owners>UK-SBCoA</Owners>
 		<PackageDescription>Dtos for API</PackageDescription>
 		<RepositoryUrl>https://github.com/UK-SBCoA/uniform-data-set-dotnet-api</RepositoryUrl>
-		<ReleaseVersion>11.0.1</ReleaseVersion>
+		<ReleaseVersion>11.0.2</ReleaseVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="System.Text.Json" Version="10.0.1" />


### PR DESCRIPTION
Resolves #118

- [x] Started PR in draft.
- [x] Stepped through new code line-by-line with the debugger ↪️ 
- [x] UI changes? Extensively tested with browser dev tools: inspect the markup, look at the console logs, and network requests. 📈 
- [x] Ran unit or Playwright tests locally (if applicable). 🧪 
- [x] Captured screenshots 💻 
- [ ] Wrote a great PR description (see [here](https://github.com/UK-SBCoA/COA/wiki/PR-Standards#pr-description)) 🦖 
- [x] Marked PR as ready for review and moved into `👀 In review`

The API was crashing when attempting to set the value of a RxNorm medication.
<img width="1362" height="641" alt="image" src="https://github.com/user-attachments/assets/50046f80-18cf-4a13-a14b-5150d07c23bf" />

This PR fixes the mapping so that the entity value of a selected RxNorm is correctly mapped with the DTO